### PR TITLE
Add workaround to fix SDL's wrong display modes

### DIFF
--- a/DanmakuEngine/Engine/GameHost.cs
+++ b/DanmakuEngine/Engine/GameHost.cs
@@ -673,7 +673,7 @@ public unsafe partial class GameHost
                     // TODO: Fetch display modes directly from XRandR
                     // Hacky workaround to fix refresh rate calculation
                     if (RuntimeInfo.IsLinux // only X11 is affected
-                        // This prevents our workaround from being applied to displays with a 60hz native resolution but has higher refresh rate in lower resolutions.
+                                            // This prevents our workaround from being applied to displays with a 60hz native resolution but has higher refresh rate in lower resolutions.
                         && max_rate > 119)
                     {
                         // see https://github.com/libsdl-org/SDL/pull/8933/files for more details

--- a/DanmakuEngine/Engine/GameHost.cs
+++ b/DanmakuEngine/Engine/GameHost.cs
@@ -288,7 +288,7 @@ public partial class GameHost : Time, IDisposable
 
         var enabled = ConfigManager.DebugMode;
 
-        if (enabled && DesktopGameHost.IsWindows && !ConfigManager.HasConsole)
+        if (enabled && RuntimeInfo.IsWindows && !ConfigManager.HasConsole)
 #pragma warning disable CA1416
             WindowsGameHost.CreateConsole();
 #pragma warning restore CA1416
@@ -477,7 +477,7 @@ public partial class GameHost : Time, IDisposable
     }
 
     public static bool HasConsole()
-        => !DesktopGameHost.IsWindows
+        => !RuntimeInfo.IsWindows
 #pragma warning disable CA1416
         || WindowsGameHost.HasConsole();
 #pragma warning restore CA1416
@@ -650,6 +650,7 @@ public unsafe partial class GameHost
             StackValue<DisplayMode> first_mode = stackalloc DisplayMode[1];
             SDL.Api.GetDisplayMode(0, 0, first_mode);
 
+            // The max refresh rate of the native display mode.
             int max_rate = first_mode.Value.RefreshRate;
 
             int nums = SDL.Api.GetNumDisplayModes(0);
@@ -669,9 +670,19 @@ public unsafe partial class GameHost
                     if (mode.W > first_mode.Value.W || mode.H > first_mode.Value.H)
                         continue;
 
+                    // TODO: Fetch display modes directly from XRandR
                     // Hacky workaround to fix refresh rate calculation
-                    if (mode.RefreshRate > max_rate)
-                        mode.RefreshRate /= 2;
+                    if (RuntimeInfo.IsLinux // only X11 is affected
+                        // This prevents our workaround from being applied to displays with a 60hz native resolution but has higher refresh rate in lower resolutions.
+                        && max_rate > 119)
+                    {
+                        // see https://github.com/libsdl-org/SDL/pull/8933/files for more details
+                        if (mode.RefreshRate > max_rate
+                            || (mode.RefreshRate > 100 && mode.RefreshRate < 118))
+                        {
+                            mode.RefreshRate /= 2;
+                        }
+                    }
 
                     modes.Add(mode);
 

--- a/DanmakuEngine/Engine/Platform/DesktopGameHost.cs
+++ b/DanmakuEngine/Engine/Platform/DesktopGameHost.cs
@@ -6,20 +6,12 @@ namespace DanmakuEngine.Engine.Platform;
 
 public class DesktopGameHost : GameHost
 {
-    public static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-
-    public static bool IsLinux => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
-
-    public static bool IsMacOS => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
-
-    public static bool IsUnix => IsLinux || IsMacOS;
-
     public static DesktopGameHost GetSuitableHost()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (RuntimeInfo.IsWindows)
             return new WindowsGameHost();
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (RuntimeInfo.IsLinux)
             return new LinuxGameHost();
 
         // Since openGL on macOS is deprecated,

--- a/DanmakuEngine/Engine/Platform/RuntimeInfo.cs
+++ b/DanmakuEngine/Engine/Platform/RuntimeInfo.cs
@@ -7,10 +7,10 @@ public static class RuntimeInfo
 #pragma warning disable IDE1006
     public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
-    public static readonly  bool IsLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+    public static readonly bool IsLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
 
-    public static readonly  bool IsMacOS = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+    public static readonly bool IsMacOS = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 
-    public static readonly  bool IsUnix = IsLinux || IsMacOS;
+    public static readonly bool IsUnix = IsLinux || IsMacOS;
 #pragma warning restore IDE1006
 }

--- a/DanmakuEngine/Engine/Platform/RuntimeInfo.cs
+++ b/DanmakuEngine/Engine/Platform/RuntimeInfo.cs
@@ -1,0 +1,16 @@
+using System.Runtime.InteropServices;
+
+namespace DanmakuEngine.Engine.Platform;
+
+public static class RuntimeInfo
+{
+#pragma warning disable IDE1006
+    public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+    public static readonly  bool IsLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+
+    public static readonly  bool IsMacOS = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+
+    public static readonly  bool IsUnix = IsLinux || IsMacOS;
+#pragma warning restore IDE1006
+}

--- a/DanmakuEngine/Engine/Platform/Windows/WindowsGameHost.cs
+++ b/DanmakuEngine/Engine/Platform/Windows/WindowsGameHost.cs
@@ -14,7 +14,7 @@ public class WindowsGameHost : DesktopGameHost
     [SupportedOSPlatform("Windows")]
     public new static bool HasConsole()
     {
-        if (!IsWindows)
+        if (!RuntimeInfo.IsWindows)
             throw new InvalidOperationException("This method is only supported on Windows");
 
         return GetConsoleWindow() != IntPtr.Zero;
@@ -29,7 +29,7 @@ public class WindowsGameHost : DesktopGameHost
         if (Configuration.ConfigManager.DebugBuild)
             return;
 
-        if (!IsWindows)
+        if (!RuntimeInfo.IsWindows)
             return;
 
         AllocConsole();

--- a/DanmakuEngine/Engine/Sleeping/IWaitHandler.cs
+++ b/DanmakuEngine/Engine/Sleeping/IWaitHandler.cs
@@ -75,7 +75,7 @@ public interface IWaitHandler
         if (_platformInstance is not null)
             return _platformInstance;
 
-        if (DesktopGameHost.IsWindows)
+        if (RuntimeInfo.IsWindows)
         {
             _platformInstance = new WindowsWaitHandler();
             _platformInstance.Register();
@@ -85,7 +85,7 @@ public interface IWaitHandler
 
             _platformInstance = null!;
         }
-        else if (DesktopGameHost.IsLinux)
+        else if (RuntimeInfo.IsLinux)
         {
             _platformInstance = new LinuxWaitHandler();
         }

--- a/DanmakuEngine/Graphics/Renderers/VeldridRenderer.cs
+++ b/DanmakuEngine/Graphics/Renderers/VeldridRenderer.cs
@@ -126,9 +126,9 @@ public class VeldridRenderer : Renderer
 
                 default:
                 {
-                    if (DesktopGameHost.IsWindows)
+                    if (RuntimeInfo.IsWindows)
                         goto case WMType.Windows;
-                    else if (DesktopGameHost.IsLinux)
+                    else if (RuntimeInfo.IsLinux)
                     {
                         Logger.Warn("============== ATTENTION ==============");
                         Logger.Warn("Failed to determine WM, defaulting to X11.");


### PR DESCRIPTION
This temporarily fixed SDL's wrong display modes. But it's also not a good implementation. Planning to fetch display modes directly from XRandR in another PR since the fix PR in SDL only applied to SDL3.