### PR TITLE
Downgrade Microsoft.CodeAnalysis.CSharp version to 4.8.0

### DIFF
--- a/DanmakuEngine.SourceGeneration/DanmakuEngine.SourceGeneration.csproj
+++ b/DanmakuEngine.SourceGeneration/DanmakuEngine.SourceGeneration.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The newest 4.9.X version of `Microsoft.CodeAnalysis.CSharp` produces CS9057 which broke our source generator.

The message:
```ascii
CSC : warning CS9057: The analyzer assembly references version '4.9.0.0' of the compiler, which is newer than the currently running version '4.8.0.0'.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Downgraded the `Microsoft.CodeAnalysis.CSharp` package for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->