### PR TITLE
Do not hack SDL's display modes on Wayland

### DIFF
--- a/DanmakuEngine/Engine/Platform/Environments/Env.cs
+++ b/DanmakuEngine/Engine/Platform/Environments/Env.cs
@@ -2,7 +2,7 @@ namespace DanmakuEngine.Engine.Platform.Environments;
 
 public static class Env
 {
-    public static string? Get<TEnv>()
+    public static string? GetString<TEnv>()
         where TEnv : IEnvironmentVariable, new()
         => new TEnv().Get();
 

--- a/DanmakuEngine/Engine/Platform/Environments/Xdg/XdgSessionTypeEnv.cs
+++ b/DanmakuEngine/Engine/Platform/Environments/Xdg/XdgSessionTypeEnv.cs
@@ -1,0 +1,33 @@
+using DanmakuEngine.Engine.Platform.Linux;
+
+namespace DanmakuEngine.Engine.Platform.Environments.Xdg;
+
+public class XdgSessionTypeEnv : IEnvironmentVariable<LinuxGraphicsPlatform>
+{
+#pragma warning disable IDE1006
+    public const string env_var = "XDG_SESSION_TYPE";
+
+    private const string x11 = "x11";
+    private const string wayland = "wayland";
+#pragma warning restore IDE1006
+    public LinuxGraphicsPlatform? Value
+    {
+        get
+        {
+            // This is not reliable though, as the user can change the value of the env
+            // But it seems that all code exists uses this value to determine the graphics platform
+            var value = Environment.GetEnvironmentVariable(env_var);
+
+            if (value is null)
+                return LinuxGraphicsPlatform.TTY;
+
+            if (value == x11)
+                return LinuxGraphicsPlatform.X11;
+
+            if (value == wayland)
+                return LinuxGraphicsPlatform.Wayland;
+
+            return LinuxGraphicsPlatform.Unknown;
+        }
+    }
+}

--- a/DanmakuEngine/Engine/Platform/Linux/LinuxGraphicsPlatform.cs
+++ b/DanmakuEngine/Engine/Platform/Linux/LinuxGraphicsPlatform.cs
@@ -1,0 +1,9 @@
+namespace DanmakuEngine.Engine.Platform.Linux;
+
+public enum LinuxGraphicsPlatform
+{
+    X11,
+    Wayland,
+    TTY,
+    Unknown
+}

--- a/DanmakuEngine/Engine/Windowing/Sdl2Window.cs
+++ b/DanmakuEngine/Engine/Windowing/Sdl2Window.cs
@@ -23,16 +23,23 @@ public unsafe class Sdl2Window : IWindow
 
     public IntPtr Handle => (IntPtr)_window;
 
+    private SysWMInfo? _sysWMInfo = null;
+
     public SysWMInfo WMInfo
     {
         get
         {
-            SysWMInfo info = default!;
+            if (!_sysWMInfo.HasValue)
+            {
+                SysWMInfo info = default!;
 
-            _sdl.GetVersion(ref info.Version);
-            _sdl.GetWindowWMInfo(_window, &info);
+                _sdl.GetVersion(ref info.Version);
+                _sdl.GetWindowWMInfo(_window, &info);
 
-            return info;
+                _sysWMInfo = info;
+            }
+
+            return _sysWMInfo.Value;
         }
     }
 
@@ -40,12 +47,12 @@ public unsafe class Sdl2Window : IWindow
     {
         get
         {
-            DisplayMode* mode = stackalloc DisplayMode[1];
+            DisplayMode mode = new();
 
-            if (_sdl.GetWindowDisplayMode(_window, mode) == 0)
+            if (_sdl.GetWindowDisplayMode(_window, &mode) != 0)
                 throw new Exception("Failed to get display mode.");
 
-            return *mode;
+            return mode;
         }
         set
         {


### PR DESCRIPTION
- **Refactor Env class and add XdgSessionTypeEnv class**
- **fix `Sdl2Window.DisplayMode`**
- **Add `LinuxGraphicsPlatform` enum and refactor display mode handling**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an enhanced method for setting display modes, including logic for selection based on available modes and refresh rates.
	- Added support for Linux graphics platform environment variables, specifically handling XDG session types.
	- Implemented a new enum for identifying Linux graphics platforms, including X11 and Wayland.
- **Refactor**
	- Improved naming conventions for methods in the `Env` class and display mode handling functions for clarity and consistency.
	- Optimized display mode logic and window properties management for better performance and reliability.
- **Bug Fixes**
	- Fixed issues with display mode setting by ensuring the method now indicates success and the applied mode properly.
- **Style**
	- Enhanced debug logging for easier troubleshooting of display mode selections in debug mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->