### PR TITLE
Refactor Time handling

### DIFF
--- a/DanmakuEngine.TH08/Games/Screens/MainScreen/MainScreen.cs
+++ b/DanmakuEngine.TH08/Games/Screens/MainScreen/MainScreen.cs
@@ -216,6 +216,19 @@ public partial class MainScreen : Screen
             ImGui.Text($"    Update: {_updateThread.AverageFramerate:F2}({1000 / _updateThread.AverageFramerate:F2}±{_updateThread.Jitter:F2}ms)");
             ImGui.Text($"    Render: {_renderThread.AverageFramerate:F2}({1000 / _renderThread.AverageFramerate:F2}±{_renderThread.Jitter:F2}ms)");
 
+            ImGui.Separator();
+
+            ImGui.Text(@"Time:");
+            ImGui.Text($"    FixedUpdateCount: {Time.FixedUpdateCount}");
+            ImGui.Text($"    FixedElapsedSeconds: {Time.FixedElapsedSeconds * 1000:F2}ms");
+            ImGui.Text($"    ElapsedSeconds: {Time.ElapsedSeconds * 1000:F2}ms");
+            ImGui.Text($"    UpdateDelta: {Time.UpdateDelta * 1000:F2}ms");
+
+            ImGui.Text($"    App time: {Time.AppTimer.GetElapsedMilliseconds():F2}ms");
+            ImGui.Text($"    Engine time: {Time.EngineTimer.GetElapsedMilliseconds():F2}ms");
+
+            ImGui.Separator();
+
             if (ImGui.Button("Close Window"))
                 _window.RequestClose();
 

--- a/DanmakuEngine/Engine/GameHost.cs
+++ b/DanmakuEngine/Engine/GameHost.cs
@@ -17,6 +17,7 @@ using DanmakuEngine.Engine.SDLNative;
 using DanmakuEngine.Engine.Sleeping;
 using DanmakuEngine.Engine.Threading;
 using DanmakuEngine.Engine.Windowing;
+using DanmakuEngine.Extensions;
 using DanmakuEngine.Games;
 using DanmakuEngine.Games.Screens;
 using DanmakuEngine.Graphics;
@@ -203,13 +204,29 @@ public partial class GameHost : Time, IDisposable
 
         Imgui.Update();
 
-        // if (window.WindowState != WindowState.Minimized)
-        //     Root.Size = new Vector2D<float>(window.Size.X, window.Size.Y);
-        _root.UpdateSubTree();
-        // Root.UpdateSubTreeMasking(Root, Root.ScreenSpaceDrawQuad.AABBFloat);
+        int updateCount = 0;
+        while (FixedElapsedSecondsNonScaled + FixedUpdateDeltaNonScaled
+            < EngineTimer.GetElapsedSeconds())
+        {
+            // never allow FixedUpdate blocks the game logic too heavily
+            if (updateCount > 5)
+            {
+                // if we are too far behind, just skip the update
+                // And add the floored skipped frames to the count
+                // This ensures the Time.ElapsedSeconds is always correct
+                FixedUpdateCount += (int)
+                    ((EngineTimer.GetElapsedSeconds() - FixedElapsedSecondsNonScaled) / FixedUpdateDeltaNonScaled);
 
-        // using (var buffer = DrawRoots.GetForWrite())
-        //     buffer.Object = Root.GenerateDrawNodeSubtree(buffer.Index, false);
+                break;
+            }
+            updateCount++;
+
+            _root.FixedUpdateSubtree();
+
+            FixedUpdateCount++;
+        }
+
+        _root.UpdateSubTree();
     }
 
     // private DrawableContainer DrawRoot = null!;
@@ -227,22 +244,6 @@ public partial class GameHost : Time, IDisposable
         Renderer.EndFrame();
 
         Renderer.SwapBuffers();
-    }
-
-    private int last_debug_fps = -1;
-    protected void DebugTime()
-    {
-        int this_debug = (int)(EngineTimer.ElapsedMilliseconds / (1000 / DebugFpsHz));
-
-        if (this_debug != last_debug_fps)
-        {
-            if (ConfigManager.HasConsole
-             && ConfigManager.DebugMode)
-            {
-                Logger.Write($"Update FPS: {UpdateThread.AverageFramerate:F2}({1000 / UpdateThread.AverageFramerate:F2}±{UpdateThread.Jitter:F2}ms), Render FPS:{RenderThread.AverageFramerate:F2}({1000 / RenderThread.AverageFramerate:F2}±{RenderThread.Jitter:F2}ms)          \r", true, false);
-                last_debug_fps = this_debug;
-            }
-        }
     }
 
     protected virtual void SetUpDebugConsole()
@@ -418,10 +419,6 @@ public partial class GameHost : Time, IDisposable
         {
             window.WindowSizeChanged += Coordinate.OnResized;
         }
-
-#if DEBUG
-        Root.OnUpdate += _ => DebugTime();
-#endif
     }
 
     public void PerformExit()

--- a/DanmakuEngine/Engine/GameHost_MainLoop.cs
+++ b/DanmakuEngine/Engine/GameHost_MainLoop.cs
@@ -28,6 +28,11 @@ public partial class GameHost
         {
             threadRunner.AddThread(RenderThread = new(Render, Renderer));
         }
+
+        foreach (var t in threadRunner.Threads)
+        {
+            t.Executor.CountCooldown = 1.0 / DebugFpsHz;
+        }
     }
 
     public void RunUntilExit()

--- a/DanmakuEngine/Engine/RootObject.cs
+++ b/DanmakuEngine/Engine/RootObject.cs
@@ -12,22 +12,4 @@ public class RootObject : DrawableContainer
     {
         Debug.Assert(LoadState is Games.LoadState.NotLoaded);
     }
-
-    protected override void update()
-    {
-        // Implementation for FixedUpdate.
-        int count = 0;
-
-        while (Time.FixedElapsedSeconds + Time.FixedUpdateDelta < Time.ElapsedSeconds
-            && count < 5) // never allow FixedUpdate blocks the game logic too heavily
-        {
-            Time.FixedElapsedSeconds += Time.FixedUpdateDelta;
-
-            count++;
-
-            FixedUpdateSubtree();
-        }
-
-        base.update();
-    }
 }

--- a/DanmakuEngine/Engine/Threading/UpdateThread.cs
+++ b/DanmakuEngine/Engine/Threading/UpdateThread.cs
@@ -21,12 +21,18 @@ public class UpdateThread : GameThread
     {
         base.postRunFrame();
 
-        Time.UpdateDelta = DeltaTime;
-        Time.UpdateDeltaF = (float)DeltaTime;
+        Time.UpdateDeltaNonScaled = DeltaTime;
+        Time.UpdateDeltaNonScaledF = (float)DeltaTime;
 
-        Time.ElapsedSeconds = ElapsedSeconds;
+        Time.ElapsedSecondsNonScaled += DeltaTime;
 
+        var delta = DeltaTime * Time.GlobalTimeScale;
 
+        Time.UpdateDelta = delta;
+        Time.UpdateDeltaF = (float)delta;
+
+        Time.ElapsedSeconds += delta;
     }
+
     public override bool IsCurrent => ThreadSync.IsUpdateThread;
 }


### PR DESCRIPTION
This PR redesigns the 'Time' in our engine. In short, the time of the engine is based on how many frames of `FixedUpdate` were executed, by `FixedElapsedSeconds`. The original `ElapsedSeconds` is `FixedElapsedSeconds` plus the elapsed time since the last `FixedUpdate`. Also, we added a `Time.GlobalTimeScale` which determines how fast the whole engine updates. And the bigger the `Time.GlobalTimeScale` is(which means faster game logic), the more frequent the `FixedUpdate` executes.

This design benefits our engine from both fixed and dynamic timestep designs. Like dynamic timestep engines, most game logic runs in `Update` at about 1000Hz, ensuring low latency.  Judgment behaviors run in `FixedUpdate` at smooth and stable 60Hz, just as we are used to. If the game can not keep stable `FixedUpdate` and encounters lagging or delay, we try to make up some of these losses but may skip some if `FixedUpdate` is blocked too heavily. When we are trying to execute `FixedUpdate`, we can't guarantee the previous frame of `Update` just ended perfectly at the time to execute `FixedUpdate`(even if the frame wasn't blocked). In this situation, the game is running a little bit slower and ends up with higger 処理落ち率. To handle this, we'll shorten the cooldown to the next `FixedUpdate` shorter.