### PR TITLE
Add NativeMemory class for allocating native memory

### DIFF
--- a/DanmakuEngine/Allocations/NativeMemory.cs
+++ b/DanmakuEngine/Allocations/NativeMemory.cs
@@ -1,0 +1,117 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using SysNativeMemory = System.Runtime.InteropServices.NativeMemory;
+
+namespace DanmakuEngine.Allocations;
+
+public static unsafe class NativeMemory
+{
+    private static bool _supportUcrt = false;
+
+    static NativeMemory()
+    {
+        var windowsVersion = Environment.OSVersion.Version;
+
+        _supportUcrt = !OperatingSystem.IsWindows() || (windowsVersion.Major > 6) || (windowsVersion.Major == 6 && windowsVersion.Minor > 2);
+    }
+
+    public static void* Alloc(UIntPtr byteCount)
+    {
+        if (_supportUcrt)
+            return SysNativeMemory.Alloc(byteCount);
+
+        return (void*)Marshal.AllocHGlobal((nint)byteCount);
+    }
+
+    public static void* Alloc(UIntPtr elementCount, UIntPtr elementSize)
+    {
+        if (_supportUcrt)
+            return SysNativeMemory.Alloc(elementCount, elementSize);
+
+        return (void*)Marshal.AllocHGlobal((nint)elementCount * (nint)elementSize);
+    }
+
+    public static void* AllocZeroed(UIntPtr byteCount)
+    {
+        if (_supportUcrt)
+            return SysNativeMemory.AllocZeroed(byteCount);
+
+        var ptr = (void*)Marshal.AllocHGlobal((nint)byteCount);
+        Unsafe.InitBlockUnaligned(ptr, 0, (uint)byteCount);
+
+        return ptr;
+    }
+
+    public static void* AllocZeroed(UIntPtr elementCount, UIntPtr elementSize)
+    {
+        if (_supportUcrt)
+            return SysNativeMemory.AllocZeroed(elementCount, elementSize);
+
+        nuint size = elementCount * elementSize;
+
+        var ptr = (void*)Marshal.AllocHGlobal((nint)size);
+        Unsafe.InitBlockUnaligned(ptr, 0, (uint)size);
+
+        return ptr;
+    }
+    public static void* AlignedAlloc(UIntPtr byteCount, UIntPtr alignment)
+        => SysNativeMemory.AlignedAlloc(byteCount, alignment);
+
+    public static void AlignedFree(void* ptr)
+        => SysNativeMemory.AlignedFree(ptr);
+
+    public static void* AlignedRealloc(void* ptr, UIntPtr byteCount, UIntPtr alignment)
+        => SysNativeMemory.AlignedRealloc(ptr, byteCount, alignment);
+
+    public static void Free(void* ptr)
+    {
+        if (_supportUcrt)
+            SysNativeMemory.Free(ptr);
+        else
+            Marshal.FreeHGlobal((nint)ptr);
+    }
+
+    public static void* Realloc(void* ptr, UIntPtr byteCount)
+    {
+        if (_supportUcrt)
+            return SysNativeMemory.Realloc(ptr, byteCount);
+
+        return (void*)Marshal.ReAllocHGlobal((IntPtr)ptr, (nint)byteCount);
+    }
+
+    public static void Clear(void* ptr, UIntPtr byteCount)
+    {
+        if (_supportUcrt)
+        {
+            SysNativeMemory.Clear(ptr, byteCount);
+        }
+        else
+        {
+            var block = new Span<byte>(ptr, (int)byteCount);
+            block.Clear();
+        }
+    }
+
+    public static void Fill(void* ptr, UIntPtr byteCount, byte value)
+    {
+        if (_supportUcrt)
+            SysNativeMemory.Fill(ptr, byteCount, value);
+        else
+            Unsafe.InitBlockUnaligned(ref *(byte*)ptr, value, (uint)byteCount);
+    }
+
+    public static void Copy(void* src, void* dst, UIntPtr byteCount)
+    {
+        if (_supportUcrt)
+        {
+            SysNativeMemory.Copy(src, dst, byteCount);
+        }
+        else
+        {
+            var srcBlock = new Span<byte>(src, (int)byteCount);
+            var dstBlock = new Span<byte>(dst, (int)byteCount);
+
+            srcBlock.CopyTo(dstBlock);
+        }
+    }
+}

--- a/DanmakuEngine/DearImgui/ImguiUtils.cs
+++ b/DanmakuEngine/DearImgui/ImguiUtils.cs
@@ -1,6 +1,7 @@
+#if !DEBUG
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-
+#endif
+using DanmakuEngine.Allocations;
 namespace DanmakuEngine.DearImgui;
 
 public static unsafe partial class ImguiUtils
@@ -17,8 +18,7 @@ public static unsafe partial class ImguiUtils
 #endif
     internal static void* ImAlloc(int size)
     {
-        void* ptr = (void*)Marshal.AllocHGlobal(size);
-        Unsafe.InitBlockUnaligned(ptr, 0, (uint)size);
+        var ptr = NativeMemory.AllocZeroed((nuint)size);
 
 #if DEBUG
         AddRecord(new((nint)ptr, (uint)size, AllocCallsite.Alloc));
@@ -38,37 +38,13 @@ public static unsafe partial class ImguiUtils
 #endif
     internal static void ImFree(nint address)
     {
-        Marshal.FreeHGlobal(address);
+        NativeMemory.Free((void*)address);
 
 #if DEBUG
         RemoveRecord(address);
         ++freedCount;
 #endif
 
-    }
-
-#if !DEBUG
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
-    internal static void ImReallocInit<T>(nint address, int count = 1)
-        where T : unmanaged
-        => ImReallocInit(address, count * sizeof(T));
-
-#if !DEBUG
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
-    internal static void* ImReallocInit(nint address, int size)
-    {
-        var ptr = (void*)Marshal.ReAllocHGlobal(address, size);
-        Unsafe.InitBlockUnaligned(ptr, 0, (uint)size);
-
-#if DEBUG
-        RemoveRecord(address);
-        AddRecord(new((nint)ptr, (uint)size, AllocCallsite.Realloc));
-        ++reallocCount;
-#endif
-
-        return ptr;
     }
 
 #if !DEBUG
@@ -83,7 +59,8 @@ public static unsafe partial class ImguiUtils
 #endif
     internal static void* ImRealloc(nint address, int size)
     {
-        var ptr = (void*)Marshal.ReAllocHGlobal(address, size);
+        var ptr = NativeMemory.Realloc((void*)address, (nuint)size);
+
 #if DEBUG
         RemoveRecord(address);
         AddRecord(new((nint)ptr, (uint)size, AllocCallsite.Realloc));

--- a/DanmakuEngine/Engine/Platform/Linux/LinuxGameHost.cs
+++ b/DanmakuEngine/Engine/Platform/Linux/LinuxGameHost.cs
@@ -1,9 +1,9 @@
-using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using DanmakuEngine.Engine.Platform.Environments;
 using DanmakuEngine.Engine.Platform.Environments.Xdg;
 using DanmakuEngine.Engine.Platform.Linux.X11;
 using DanmakuEngine.Engine.SDLNative;
+using DanmakuEngine.Allocations;
 using DanmakuEngine.Extensions;
 using DanmakuEngine.Logging;
 using OpenTK.Windowing.GraphicsLibraryFramework;
@@ -112,13 +112,13 @@ public unsafe partial class LinuxGameHost : DesktopGameHost
                         var mode = new SDL_DisplayMode
                         {
                             Format = format,
-                            Driverdata = (SDL_DisplayModeData*)Marshal.AllocHGlobal(sizeof(SDL_DisplayModeData)),
+                            Driverdata = (SDL_DisplayModeData*)NativeMemory.Alloc((nuint)sizeof(SDL_DisplayModeData)),
                         };
 
                         if (!setXRandRModeInfo(display, screen, output_info->crtc,
                             output_info->modes[j], ref mode))
                         {
-                            Marshal.FreeHGlobal((IntPtr)mode.Driverdata);
+                            NativeMemory.Free(mode.Driverdata);
                             continue;
                         }
 

--- a/DanmakuEngine/Engine/Platform/Linux/LinuxGameHost.cs
+++ b/DanmakuEngine/Engine/Platform/Linux/LinuxGameHost.cs
@@ -1,9 +1,9 @@
 using System.Runtime.Versioning;
+using DanmakuEngine.Allocations;
 using DanmakuEngine.Engine.Platform.Environments;
 using DanmakuEngine.Engine.Platform.Environments.Xdg;
 using DanmakuEngine.Engine.Platform.Linux.X11;
 using DanmakuEngine.Engine.SDLNative;
-using DanmakuEngine.Allocations;
 using DanmakuEngine.Extensions;
 using DanmakuEngine.Logging;
 using OpenTK.Windowing.GraphicsLibraryFramework;


### PR DESCRIPTION
The code changes introduce a new `NativeMemory` class in the `DanmakuEngine.Allocations` namespace. This class is a wrapper for `System.Runtime.InteropServices.NativeMemory` with fallback for older machines that does not support Universal C Runtime.
